### PR TITLE
Support parsing of string with multiple identifiers

### DIFF
--- a/lib/library_stdnums.rb
+++ b/lib/library_stdnums.rb
@@ -21,6 +21,18 @@ module StdNum
       return (match[1].gsub(/\-/, '')).upcase
     end
 
+    # Same as STDNUMPAT but allowing for all numbers in the provided string
+    STDNUMPAT_MULTIPLE = /.*?(\d[\d\-]{6,}[xX]?)/
+
+    # Extract the most likely looking numbers from the string. This will be each
+    # string with digits-and-hyphens-and-maybe-a-trailing-X, with the hypens removed
+    # @param [String] str The string from which to extract the ISBN/ISSNs
+    # @return [Array] An array of extracted identifiers
+    def extract_multiple_numbers(str)
+      return if str == '' || str.nil?
+      str.scan(STDNUMPAT_MULTIPLE).flatten.map{ |i| i.gsub(/\-/, '').upcase }
+    end
+
     # Given any string, extract what looks like the most likely ISBN/ISSN
     # of the given size(s), or nil if nothing matches at the correct size.
     # @param [String] rawnum The raw string containing (hopefully) an ISSN/ISBN
@@ -51,12 +63,12 @@ module StdNum
   # Validate, convert, and normalize ISBNs (10-digit or 13-digit)
   module ISBN
     extend Helpers
-    
+
     # Does it even look like an ISBN?
     def self.at_least_trying? isbn
       reduce_to_basics(isbn, [10,13]) ? true : false
     end
-    
+
 
     # Compute check digits for 10 or 13-digit ISBNs. See algorithm at
     # http://en.wikipedia.org/wiki/International_Standard_Book_Number
@@ -92,7 +104,7 @@ module StdNum
     # Check to see if the checkdigit is correct
     # @param [String] isbn The ISBN (we'll try to clean it up if possible)
     # @param [Boolean] preprocessed Set to true if the ISBN has already been through reduce_to_basics
-    # @return [Boolean] Whether or not the checkdigit is correct. Sneakily, return 'nil' for 
+    # @return [Boolean] Whether or not the checkdigit is correct. Sneakily, return 'nil' for
     #  values that don't even look like ISBNs, and 'false' for those that look possible but
     #  don't normalize / have bad checkdigits
     def self.valid? isbn, preprocessed = false
@@ -210,7 +222,7 @@ module StdNum
     # Check to see if the checkdigit is correct
     # @param [String] issn The ISSN (we'll try to clean it up if possible)
     # @param [Boolean] preprocessed Set to true if the number has already been through reduce_to_basic
-    # @return [Boolean] Whether or not the checkdigit is correct. Sneakily, return 'nil' for 
+    # @return [Boolean] Whether or not the checkdigit is correct. Sneakily, return 'nil' for
     #  values that don't even look like ISBNs, and 'false' for those that look possible but
     #  don't normalize / have bad checkdigits
 

--- a/lib/library_stdnums.rb
+++ b/lib/library_stdnums.rb
@@ -29,7 +29,7 @@ module StdNum
     # @param [String] str The string from which to extract the ISBN/ISSNs
     # @return [Array] An array of extracted identifiers
     def extract_multiple_numbers(str)
-      return if str == '' || str.nil?
+      return [] if str == '' || str.nil?
       str.scan(STDNUMPAT_MULTIPLE).flatten.map{ |i| i.gsub(/\-/, '').upcase }
     end
 

--- a/lib/library_stdnums/version.rb
+++ b/lib/library_stdnums/version.rb
@@ -1,4 +1,4 @@
 module StdNum
   # library_stdnums version
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end

--- a/spec/library_stdnums_spec.rb
+++ b/spec/library_stdnums_spec.rb
@@ -41,6 +41,14 @@ describe "Extract" do
     StdNum::ISBN.extract_multiple_numbers(identifiers_string)[1].must_equal '9780987115430'
   end
 
+  let(:string_with_no_identifiers) { 'This has no identifiers' }
+  it "will return an empty array when no identifiers are in the supplied string " do
+    StdNum::ISBN.extract_multiple_numbers(string_with_no_identifiers).must_be_kind_of Array
+    StdNum::ISBN.extract_multiple_numbers(string_with_no_identifiers).count.must_equal 0
+
+    StdNum::ISBN.extract_multiple_numbers('').must_be_kind_of Array
+    StdNum::ISBN.extract_multiple_numbers('').count.must_equal 0
+  end
   it "skips over short prefixing numbers" do
     StdNum::ISBN.extractNumber('ISBN13: 1234567890123').must_equal '1234567890123'
   end

--- a/spec/library_stdnums_spec.rb
+++ b/spec/library_stdnums_spec.rb
@@ -33,6 +33,14 @@ describe "Extract" do
     StdNum::ISBN.extractNumber('12345').must_equal nil
   end
 
+  let(:identifiers_string) { '9780987115423 (print ed) 9780987115430 (web ed)' }
+  it "will extract multiple identifiers" do
+    StdNum::ISBN.extract_multiple_numbers(identifiers_string).must_be_kind_of Array
+    StdNum::ISBN.extract_multiple_numbers(identifiers_string).count.must_equal 2
+    StdNum::ISBN.extract_multiple_numbers(identifiers_string)[0].must_equal '9780987115423'
+    StdNum::ISBN.extract_multiple_numbers(identifiers_string)[1].must_equal '9780987115430'
+  end
+
   it "skips over short prefixing numbers" do
     StdNum::ISBN.extractNumber('ISBN13: 1234567890123').must_equal '1234567890123'
   end
@@ -64,18 +72,18 @@ describe "ISBN" do
   it "finds a good number valid" do
     StdNum::ISBN.valid?('9780306406157').must_equal true
   end
-  
+
   it "says a good number is trying" do
     StdNum::ISBN.at_least_trying?('9780306406157').must_equal true
   end
-  
+
   it "says bad data is not trying" do
     StdNum::ISBN.at_least_trying?('978006406157').must_equal false
     StdNum::ISBN.at_least_trying?('406157').must_equal false
     StdNum::ISBN.at_least_trying?('$22').must_equal false
     StdNum::ISBN.at_least_trying?('hello').must_equal false
   end
-    
+
 
   it "finds a bad number invalid" do
     StdNum::ISBN.valid?('9780306406154').must_equal false


### PR DESCRIPTION
I've been doing some work with the [RIS](http://en.wikipedia.org/wiki/RIS_%28file_format%29) format and have had all sorts of weird and worderful interpretations of how to record identifiers for documents.  To support this (as it's not going away in a hurry) I've added a method (StdNum::Helpers. extract_multiple_numbers) for extraction of multiple identifiers based on the StdNum::Helpers.extractNumber.

So what we get is the following:

``` ruby
string = '9780987115423 (print ed) 9780987115430 (web ed)' 
array_with_matches = ['9780987115423', '9780987115430']
```

Let me know what you think
